### PR TITLE
Added basic sparql test for fetching cites from OCC

### DIFF
--- a/occ_adapter/README.md
+++ b/occ_adapter/README.md
@@ -1,0 +1,4 @@
+Install
+-------
+
+pip install -r requirements.txt --user

--- a/occ_adapter/requirements.txt
+++ b/occ_adapter/requirements.txt
@@ -1,0 +1,1 @@
+SPARQLWrapper

--- a/occ_adapter/test.py
+++ b/occ_adapter/test.py
@@ -1,0 +1,29 @@
+from SPARQLWrapper import SPARQLWrapper, JSON
+
+sparql = SPARQLWrapper("http://opencitations.net/sparql")
+sparql.setQuery("""
+PREFIX cito: <http://purl.org/spar/cito/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX datacite: <http://purl.org/spar/datacite/>
+PREFIX literal: <http://www.essepuntato.it/2010/06/literalreification/>
+PREFIX biro: <http://purl.org/spar/biro/>
+PREFIX frbr: <http://purl.org/vocab/frbr/core#>
+PREFIX c4o: <http://purl.org/spar/c4o/>
+SELECT ?cited ?title ?url WHERE {
+    ?main cito:cites ?cited .
+    ?cited dcterms:title ?title .		
+    ?main frbr:part ?ref .
+    ?ref biro:references ?cited .
+    ?cited datacite:hasIdentifier [
+        datacite:usesIdentifierScheme datacite:url ;
+        literal:hasLiteralValue ?url
+    ] .
+    ?main datacite:hasIdentifier [
+        datacite:usesIdentifierScheme datacite:url ;
+        literal:hasLiteralValue 'http://dx.doi.org/10.1097/igc.0000000000000609'
+    ]
+}
+""")
+sparql.setReturnFormat(JSON)
+results = sparql.query().convert()
+print(results)


### PR DESCRIPTION
Could be expanded into an adapter that takes a DOI URL as an input and returns the list of references. The test returns (ID, title, url) for each reference. Other info (e.g abstract) to be investigated.